### PR TITLE
fix: sensitive keys lookup

### DIFF
--- a/examples/complete/apim.tf
+++ b/examples/complete/apim.tf
@@ -1,6 +1,6 @@
 locals {
   apim = {
-    name                 = module.naming.api_management.name
+    name                 = module.naming.api_management.name_unique
     resource_group       = module.rg.groups.demo.name
     location             = module.rg.groups.demo.location
     sku_name             = "Developer_1"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -19,19 +19,19 @@ module "rg" {
 
 module "vnet" {
   source  = "cloudnationhq/vnet/azure"
-  version = "~> 4.0"
+  version = "~> 9.0"
 
   naming = local.naming
 
   vnet = {
-    name           = module.naming.virtual_network.name
-    location       = module.rg.groups.demo.location
-    resource_group = module.rg.groups.demo.name
-    cidr           = ["10.0.0.0/16"]
+    name                = module.naming.virtual_network.name
+    location            = module.rg.groups.demo.location
+    resource_group_name = module.rg.groups.demo.name
+    address_space       = ["10.0.0.0/16"]
     subnets = {
       sn1 = {
-        cidr = ["10.0.0.0/24"]
-        nsg = {
+        address_prefixes = ["10.0.0.0/24"]
+        network_security_group = {
           rules = local.apim_nsg_rules
         }
       }
@@ -41,14 +41,14 @@ module "vnet" {
 
 module "kv" {
   source  = "cloudnationhq/kv/azure"
-  version = "~> 2.0"
+  version = "~> 4.0"
 
   naming = local.naming
 
   vault = {
-    name           = module.naming.key_vault.name_unique
-    location       = module.rg.groups.demo.location
-    resource_group = module.rg.groups.demo.name
+    name                = module.naming.key_vault.name_unique
+    location            = module.rg.groups.demo.location
+    resource_group_name = module.rg.groups.demo.name
 
     certs = local.certs
   }
@@ -56,15 +56,15 @@ module "kv" {
 
 module "redis" {
   source  = "cloudnationhq/redis/azure"
-  version = "~> 2.0"
+  version = "~> 3.0"
 
   cache = {
-    name           = module.naming.redis_cache.name
-    resource_group = module.rg.groups.demo.name
-    location       = module.rg.groups.demo.location
-    sku_name       = "Basic"
-    capacity       = 1
-    family         = "C"
+    name                = module.naming.redis_cache.name_unique
+    resource_group_name = module.rg.groups.demo.name
+    location            = module.rg.groups.demo.location
+    sku_name            = "Basic"
+    capacity            = 0
+    family              = "C"
   }
 }
 

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -22,7 +22,7 @@ module "apim" {
   version = "~> 2.0"
 
   config = {
-    name            = module.naming.api_management.name
+    name            = module.naming.api_management.name_unique
     resource_group  = module.rg.groups.demo.name
     location        = module.rg.groups.demo.location
     sku_name        = "Developer_1"

--- a/main.tf
+++ b/main.tf
@@ -236,7 +236,7 @@ resource "azurerm_api_management_custom_domain" "apim" {
 }
 
 resource "azurerm_api_management_redis_cache" "apim" {
-  for_each          = lookup(var.config, "redis_cache", null) != null ? { default = var.config.redis_cache } : {}
+  for_each          = nonsensitive(lookup(var.config, "redis_cache", null) != null ? { default = var.config.redis_cache } : {})
   name              = each.value.name
   api_management_id = azurerm_api_management.apim.id
   connection_string = each.value.connection_string
@@ -246,7 +246,7 @@ resource "azurerm_api_management_redis_cache" "apim" {
 }
 
 resource "azurerm_api_management_logger" "logger" {
-  for_each            = lookup(var.config, "logger", null) != null ? { default = var.config.logger } : {}
+  for_each            = nonsensitive(lookup(var.config, "logger", null) != null ? { default = var.config.logger } : {})
   name                = each.value.name
   resource_group_name = coalesce(lookup(var.config, "resource_group", null), var.resource_group)
   api_management_name = azurerm_api_management.apim.name


### PR DESCRIPTION
## Description

Fixing sensitive keys error:
Error: Sensitive values, or values derived from sensitive values, cannot be used as for_each arguments. If used, the
│ sensitive value could be exposed as a resource instance key.

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #24 
